### PR TITLE
Optimize getting position

### DIFF
--- a/horizontalcalendar/build.gradle
+++ b/horizontalcalendar/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:25.2.0'
     compile 'com.android.support:recyclerview-v7:25.2.0'
+    compile 'net.danlew:android.joda:2.9.9'
 }
 
 

--- a/horizontalcalendar/src/main/java/devs/mulham/horizontalcalendar/HorizontalCalendar.java
+++ b/horizontalcalendar/src/main/java/devs/mulham/horizontalcalendar/HorizontalCalendar.java
@@ -9,6 +9,11 @@ import android.support.v7.widget.LinearSnapHelper;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
+import net.danlew.android.joda.JodaTimeAndroid;
+
+import org.joda.time.Days;
+import org.joda.time.LocalDate;
+
 import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -363,14 +368,22 @@ public class HorizontalCalendar {
      * @return position of date in Calendar, or -1 if date does not exist
      */
     public int positionOfDate(Date date) {
-        int position = -1;
-        for (int i = 0; i < mListDays.size(); i++) {
-            if (isDatesDaysEquals(date, mListDays.get(i))) {
-                position = i;
-                break;
-            }
+        LocalDate prevDate = toLocalDate(mListDays.get(0));
+        LocalDate newDate = toLocalDate(date);
+
+        int diff = Days.daysBetween(prevDate, newDate).getDays();
+
+        if (diff < mListDays.size() && prevDate.isBefore(newDate)) {
+            return diff;
         }
-        return position;
+
+        return -1;
+    }
+
+    public LocalDate toLocalDate(Date date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        return new LocalDate (cal.get(Calendar.YEAR), cal.get(Calendar.MONTH)+1, cal.get(Calendar.DAY_OF_MONTH));
     }
 
     /**
@@ -607,6 +620,8 @@ public class HorizontalCalendar {
             mCalendarAdapter = new HorizontalCalendarAdapter(calendarView, mListDays);
             calendarView.setAdapter(mCalendarAdapter);
             calendarView.setLayoutManager(new HorizontalLayoutManager(calendarView.getContext(), false));
+
+            JodaTimeAndroid.init(calendarView.getContext());
 
             if (centerToday) {
                 goToday(true);


### PR DESCRIPTION
this snippet is too expensive specially when `mListDays.size()` is big
```java
for (int i = 0; i < mListDays.size(); i++) {
    if (isDatesDaysEquals(date, mListDays.get(i))) {
        position = i;
        break;
    }
}
```

to optimize, we just need to make sure that the date we are looking for is after the start date and before the end date. we can use [JodaTimeAndroid](https://github.com/dlew/joda-time-android) for this

```java
//create jodatime readable dates
LocalDate prevDate = toLocalDate(mListDays.get(0));
LocalDate newDate = toLocalDate(date);

//get the difference between the start date and the target date in days
int diff = Days.daysBetween(prevDate, newDate).getDays();

//make sure that the target date is within the bounds
if (diff < mListDays.size() && prevDate.isBefore(newDate)) {
    return diff;
}
```