### PR TITLE
Fixed ArrayIndexOutOfBoundsException

### DIFF
--- a/horizontalcalendar/src/main/java/devs/mulham/horizontalcalendar/HorizontalCalendarAdapter.java
+++ b/horizontalcalendar/src/main/java/devs/mulham/horizontalcalendar/HorizontalCalendarAdapter.java
@@ -54,6 +54,9 @@ class HorizontalCalendarAdapter extends RecyclerView.Adapter<HorizontalCalendarA
         holder.rootView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                if(holder.getAdapterPosition() == -1)
+                    return;
+
                 Date date = datesList.get(holder.getAdapterPosition());
 
                 if (!date.before(horizontalCalendar.getDateStartCalendar())


### PR DESCRIPTION
Mulham, hello.
I’m using your library now, best library, but recently I collided with an error. It consists in the following, when in case of synchronous clicking different dates, HorizontCalendar gives error ArrayIndexOutOfBoundsException, output out of array limits with an index -1, debugging I found the place where it occurs, event onClick() in the class HorizontalCalendarAdapter, namely holder.getAdapterPosition() can return -1, in the investigation of list -> datesList.get( holder.getAdapterPosition() ); gives error.