### PR TITLE
Fixes issue #20

### DIFF
--- a/horizontalcalendar/src/main/java/devs/mulham/horizontalcalendar/HorizontalCalendar.java
+++ b/horizontalcalendar/src/main/java/devs/mulham/horizontalcalendar/HorizontalCalendar.java
@@ -166,6 +166,7 @@ public class HorizontalCalendar {
         } else {
             if (immediate) {
                 centerToPositionWithNoAnimation(positionOfDate(date));
+                calendarListener.onDateSelected(date, positionOfDate(date));
             } else {
                 calendarView.setSmoothScrollSpeed(HorizontalLayoutManager.SPEED_NORMAL);
                 centerCalendarToPosition(positionOfDate(date));

--- a/horizontalcalendar/src/main/java/devs/mulham/horizontalcalendar/HorizontalCalendar.java
+++ b/horizontalcalendar/src/main/java/devs/mulham/horizontalcalendar/HorizontalCalendar.java
@@ -165,8 +165,9 @@ public class HorizontalCalendar {
             handler.immediate = immediate;
         } else {
             if (immediate) {
-                centerToPositionWithNoAnimation(positionOfDate(date));
-                calendarListener.onDateSelected(date, positionOfDate(date));
+                int datePosition = positionOfDate(date);
+                centerToPositionWithNoAnimation(datePosition);
+                calendarListener.onDateSelected(date, datePosition);
             } else {
                 calendarView.setSmoothScrollSpeed(HorizontalLayoutManager.SPEED_NORMAL);
                 centerCalendarToPosition(positionOfDate(date));


### PR DESCRIPTION
I didn't quite see the purpose of `position` in the `onDateSelected()` callback. In fact I was able to remove it without any issue. That said, I hope `positionOfDate()` does what I think it does.

Having the `onDateSelected()` invocation rely on the scroll to finish doesn't quite sit right with me. Perhaps it would be valuable to have a more accurate timing as to when the function gets called.

Anyway, here's a quick little bugfix to address #20, but it isn't very robust. A better fix would be to address the odd timing of the callback mentioned above. 

Thanks for your consideration!