### PR TITLE
Fix InflateException

### DIFF
--- a/horizontalcalendar/src/main/res/layout/hc_item_calendar.xml
+++ b/horizontalcalendar/src/main/res/layout/hc_item_calendar.xml
@@ -9,7 +9,7 @@
         android:id="@+id/hc_layoutContent"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="?selectableItemBackground"
+        android:background="?android:attr/selectableItemBackground"
         android:layout_marginBottom="5dp"
         android:gravity="center"
         android:orientation="vertical"


### PR DESCRIPTION
Some people including myself suffered from this exception. 
`android.view.InflateException: Binary XML file line #0: Binary XML file line #0: Error inflating class devs.mulham.horizontalcalendar.HorizontalCalendarView`
I investigated and found out that the missing android reference is missing in the background attribute.